### PR TITLE
Fix names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ TLDR:
 
 Install the package from your terminal:
 
-      elm install elm/bugsnag-elm
+      elm install tremlab/bugsnag-elm
 
 Initialize bugsnag for your app:
 
       bugsnag = BugsnagElm.start
-          { token = "abcdef1234...."
-          , codeVersion = "xyz0101010......"
+          { apiKey = "abcdef1234...."
+          , appVersion = "xyz0101010......"
           , releaseStage = "test"
           , enabledReleaseStages = ["production", "staging", "test"]
           , user =

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -10,8 +10,8 @@ import Json.Encode
 import Task
 
 
-token : String
-token =
+apiKey : String
+apiKey =
     -- The api key to the Bugsnag project you want to report errors to.
     -- Bugsnag doesn't formally support Elm, so create a generic JS project.
     -- Bugsnag offers free single-user accounts - go ahead and play around!
@@ -22,7 +22,7 @@ token =
 bugsnag : Bugsnag
 bugsnag =
     BugsnagElm.start
-        { token = token
+        { apiKey = apiKey
         , codeVersion = "24dcf3a9a9cf1a5e2ea319018644a68f4743a731"
         , releaseStage = "test"
         , enabledReleaseStages = ["production", "staging", "test"]

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -23,7 +23,7 @@ bugsnag : Bugsnag
 bugsnag =
     BugsnagElm.start
         { apiKey = apiKey
-        , codeVersion = "24dcf3a9a9cf1a5e2ea319018644a68f4743a731"
+        , appVersion = "24dcf3a9a9cf1a5e2ea319018644a68f4743a731"
         , releaseStage = "test"
         , enabledReleaseStages = ["production", "staging", "test"]
         , user =

--- a/src/BugsnagElm.elm
+++ b/src/BugsnagElm.elm
@@ -15,7 +15,7 @@ module BugsnagElm exposing
     bugsnug =
         BugsnagElm.start
             { apiKey = "abcdef1234...."
-            , codeVersion = "xyz0101010......"
+            , appVersion = "xyz0101010......"
             , releaseStage = "test"
             , enabledReleaseStages = ["production", "staging", "test"]
             , user =
@@ -91,7 +91,7 @@ Applies to all error reports that may occur in the app,
 with error-specific data added later in `notify`
 
   - `apiKey` - The [Bugsnag API apiKey](https://Bugsnag.com/docs/api/#authentication) required to authenticate the request.
-  - `codeVersion` - However your app identifies its versions, include it here as a string
+  - `appVersion` - However your app identifies its versions, include it here as a string
   - `releaseStage` - usually `"production"`, `"development"`, `"staging"`, etc., but bugsnag accepts any value
   - `enabledReleaseStages` - explictly define which stages you want to report, omitting any you'd prefer to drop (e.g. "development"). Empty list will report ALL error stages.
   - `user` - if available, report default user data (id, name, email)
@@ -99,7 +99,7 @@ with error-specific data added later in `notify`
 -}
 type alias BugsnagConfig =
     { apiKey : String
-    , codeVersion : String
+    , appVersion : String
     , releaseStage : String
     , enabledReleaseStages : List String
     , user : Maybe User
@@ -130,7 +130,7 @@ type alias User =
 
     bugsnag = BugsnagElm.start
         { apiKey = "abcdef1234...."
-        , codeVersion = "xyz0101010......"
+        , appVersion = "xyz0101010......"
         , releaseStage = "test"
         , enabledReleaseStages = ["production", "staging", "test"]
         , user =
@@ -294,7 +294,7 @@ toJsonBody bugsnagConfig severity message context metadata =
                    )
                  , ( "app"
                    , Encode.object
-                        [ ( "version", Encode.string bugsnagConfig.codeVersion )
+                        [ ( "version", Encode.string bugsnagConfig.appVersion )
                         , ( "releaseStage", Encode.string bugsnagConfig.releaseStage )
                         , ( "type", Encode.string "elm" )
                         ]

--- a/src/BugsnagElm.elm
+++ b/src/BugsnagElm.elm
@@ -14,7 +14,7 @@ module BugsnagElm exposing
     bugsnag : Bugsnag
     bugsnug =
         BugsnagElm.start
-            { token = "abcdef1234...."
+            { apiKey = "abcdef1234...."
             , codeVersion = "xyz0101010......"
             , releaseStage = "test"
             , enabledReleaseStages = ["production", "staging", "test"]
@@ -66,7 +66,7 @@ import Json.Encode as Encode exposing (Value)
 import Task exposing (Task)
 
 
-{-| Functions preapplied with access token, code version, user info and releaseStage,
+{-| Functions preapplied with apiKey, code version, user info and releaseStage,
 separated by [`Severity`](#Severity).
 
 Create one using [`start`](#start), and then throughout your app you can call `bugsnag.error` to send the error report.
@@ -90,7 +90,7 @@ type alias Bugsnag =
 Applies to all error reports that may occur in the app,
 with error-specific data added later in `notify`
 
-  - `token` - The [Bugsnag API token](https://Bugsnag.com/docs/api/#authentication) required to authenticate the request.
+  - `apiKey` - The [Bugsnag API apiKey](https://Bugsnag.com/docs/api/#authentication) required to authenticate the request.
   - `codeVersion` - However your app identifies its versions, include it here as a string
   - `releaseStage` - usually `"production"`, `"development"`, `"staging"`, etc., but bugsnag accepts any value
   - `enabledReleaseStages` - explictly define which stages you want to report, omitting any you'd prefer to drop (e.g. "development"). Empty list will report ALL error stages.
@@ -98,7 +98,7 @@ with error-specific data added later in `notify`
 
 -}
 type alias BugsnagConfig =
-    { token : String
+    { apiKey : String
     , codeVersion : String
     , releaseStage : String
     , enabledReleaseStages : List String
@@ -129,7 +129,7 @@ type alias User =
 {-| Return a [`Bugsnag`](#Bugsnag) record configured with the given BugsnagConfig details.
 
     bugsnag = BugsnagElm.start
-        { token = "abcdef1234...."
+        { apiKey = "abcdef1234...."
         , codeVersion = "xyz0101010......"
         , releaseStage = "test"
         , enabledReleaseStages = ["production", "staging", "test"]
@@ -182,7 +182,7 @@ notify bugsnagConfig severity message context metadata =
         True ->
             { method = "POST"
             , headers =
-                [ Http.header "Bugsnag-Api-Key" bugsnagConfig.token
+                [ Http.header "Bugsnag-Api-Key" bugsnagConfig.apiKey
                 , Http.header "Bugsnag-Payload-Version" "5"
                 ]
             , url = endpointUrl


### PR DESCRIPTION
For consistency with official Bugsnag notifiers renaming:

- token -> apiKey 
- codeVersion -> appVersion 

e.g. see https://docs.bugsnag.com/platforms/javascript/configuration-options/#setting-configuration-options